### PR TITLE
Fix ApiStatusServiceTest

### DIFF
--- a/tests/Services/TestApiStatusService.php
+++ b/tests/Services/TestApiStatusService.php
@@ -20,14 +20,14 @@ class TestApiStatusService extends LlocTestCase {
 		$client->shouldReceive( 'get_service' )->once()->andReturn( $service );
 
 		$response = \Mockery::mock( ResponseInterface::class );
-		$response->shouldReceive( 'get' )->once()->andReturn( array( 'status' => 'ok' ) );
+		$response->shouldReceive( 'get' )->once()->andReturn( array( 'message' => 'OK' ) );
 
 		$api_status = \Mockery::mock( ApiStatus::class );
 		$api_status->shouldReceive( 'get' )->once()->andReturn( $response );
 		$api_status->shouldReceive( 'get_client' )->once()->andReturn( $client );
 
 		$expected = array(
-			'status' => 'ok',
+			'status' => 'OK',
 			'info'   => 'Sandbox',
 		);
 


### PR DESCRIPTION
Fixing the expected response in the ApiStatusService test. The class under test was modified by [this](https://github.com/lloc/wp-nowpayments-integration/commit/bfad0b5bd2cca105fffe28fe1843d50a1a339b78) previous commit.

I also verified the body of the response in the documentation [here](https://documenter.getpostman.com/view/7907941/2s93JusNJt#0316fd95-ad58-4d36-82c0-d94455d019ac), so I do confirm the test was the one to change.